### PR TITLE
updated basic info and events for SS25

### DIFF
--- a/src/config.tex
+++ b/src/config.tex
@@ -5,27 +5,27 @@
 % 1. Professoren für Mathe und Info eintragen
 % Titel mit eintragen, damit man in den Terminen nicht If-en muss falls Britta Mathe hält
 \newcommand{\Matheprof}{Prof. Eckstein}
-\newcommand{\Infoprof}{Prof. Grust}
+\newcommand{\Infoprof}{Prof. Lensch}
 
 % 2. Ticketpreise anpassen
-% Link WS23 https://www.naldo.de/tickets/semesterticket/
-\newcommand{\semesterticketpreis}{141,90}
+% Link SS25 https://www.naldo.de/tickets/semesterticket/
+\newcommand{\semesterticketpreis}{153,10}
 % https://www.naldo.de/tickets/dticket-jugendbw-studierende/
-\newcommand{\jugendticketbwpreis}{153,70}
+\newcommand{\jugendticketbwpreis}{236,52}
 % https://www.swtue.de/oepnv/tickets/deutschlandticket-fuer-uebersicht.html
-\newcommand{\detickettuepreis}{34,00}
+\newcommand{\detickettuepreis}{45,00}
 
-% Link WS24 https://uni-tuebingen.de/fakultaeten/mathematisch-naturwissenschaftliche-fakultaet/fachbereiche/informatik/studium/studienbeginn/mathematischer-vorbereitungskurs/
+% Link SS25 https://uni-tuebingen.de/fakultaeten/mathematisch-naturwissenschaftliche-fakultaet/fachbereiche/informatik/studium/studienbeginn/mathematischer-vorbereitungskurs/
 % 3. Mathe Vorkurs
-\newcommand{\matheanmeldung}{26.09.} 		      % Anmeldeschluss (ohne Jahr, mit Punkt am Ende. Bsp.: 31.03.)
-\newcommand{\mathedatum}{Dienstag, 01. Oktober}     % Beginn (Wochentag, Tag. Monat)
-\newcommand{\mathkontakt}{alfredo.cantarella@uni-tuebingen.de}
+\newcommand{\matheanmeldung}{28.03.} 		      % Anmeldeschluss (ohne Jahr, mit Punkt am Ende. Bsp.: 31.03.)
+\newcommand{\mathedatum}{Dienstag, 01. April}             % Beginn (Wochentag, Tag. Monat)
+\newcommand{\mathkontakt}{britta.dorn@uni-tuebingen.de} 
 
 
 % 4. Anmeldeschluss Informatik Vorkurs für Lebenswissenschaftler (BioInfo Master Variante B ohne Jahr, mit Punkt)
 % Link WS24 https://uni-tuebingen.de/de/215092
 
-\newcommand{\bioinfoAnmeldung}{16.09.}		     % Anmeldeschluss (ohne Jahr, mit Punkt am Ende. Bsp.: 31.03.)
-\newcommand{\bioinfoDatum}{Montag, 23. September} % Beginn (Wochentag, Tag. Monat)
+\newcommand{\bioinfoAnmeldung}{17.03.}		     % Anmeldeschluss (ohne Jahr, mit Punkt am Ende. Bsp.: 31.03.)
+\newcommand{\bioinfoDatum}{Montag, 31. März} % Beginn (Wochentag, Tag. Monat)
 \newcommand{\bioinfoKontakt}{philipp.thiel@uni-tuebingen.de}
 

--- a/src/einleitung.tex
+++ b/src/einleitung.tex
@@ -42,6 +42,6 @@ Deine Fachschaften Kognitionswissenschaft und Informatik
 \else
 Deine Fachschaft Informatik
 \par\hfill
-{\footnotesize Redaktion: Charlotte, Fine \& Samuel}
+{\footnotesize Redaktion: Charlotte}
 \fi
 \vfill

--- a/src/einleitung_en.tex
+++ b/src/einleitung_en.tex
@@ -22,7 +22,7 @@ We're excited to meet you at our beginners events!\\
 %\vfill
 Your student council of computer science
 \enlargethispage{3\baselineskip} % we dont want the last line(s) to be put on an extra page
-\par\hfill{\footnotesize Editors: Charlotte, Fine \& Samuel}
+\par\hfill{\footnotesize Editors: Charlotte}
 \vfill
 
 % \noindent\makebox[\textwidth][c]{%

--- a/src/mailinglisten.tex
+++ b/src/mailinglisten.tex
@@ -17,7 +17,7 @@ Anmeldung unter: \url{https://www.fsi.uni-tuebingen.de/mailman/listinfo/versuche
 \fi
 \item \texttt{info-talk}: Diese Liste ist für Themen, die nicht direkt mit dem Studium zu tun haben, aber dennoch von Interesse sein können.\\
 Anmeldung unter: \url{https://www.fsi.uni-tuebingen.de/mailman/listinfo/info-talk}.
-\item \texttt{info-jobs}: Für bezahlte Angebote von HiWi\footnote{wissenschaftliche/studentische Hilfskraft}-Jobs, Praktika sowie  Werksstudentenjobs.\\
+\item \texttt{info-jobs}: Für bezahlte Angebote von Minijobs, Praktika sowie  Werksstudentenjobs.\\
 Anmeldung unter: \url{https://www.fsi.uni-tuebingen.de/mailman/listinfo/info-jobs}.
 \item \texttt{coding}: Hackathons und andere Veranstaltungen zum Coden.\\
 Anmeldung unter: \url{https://www.fsi.uni-tuebingen.de/mailman/listinfo/coding}.

--- a/src/termine.tex
+++ b/src/termine.tex
@@ -93,15 +93,41 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Ab hier die FSI Events einfügen. Darüber sind der Mathe und Info vorkurs.
 
+% Erste Vorlesung
+\ifbachelor
+    \item[Erste Vorlesung -- Montag, 14. April \YEAR, \ifwintersemester 8:00 Uhr, \else 10:00 Uhr, \fi Morgenstelle]~\\
+    Deine erste Vorlesung beginnt um
+    \ifwintersemester 8:00 Uhr -- Du hast „Mathematik für Informatik 1“  \fi
+    \ifsommersemester 10:00 Uhr -- Du hast „Mathematik für Informatik 2“  \fi
+    bei \Matheprof.
+    Alles, was du heute (und in Zukunft) benötigst: persönlichen Wachmacher, einen Stift, einen Block und den Studierendenausweis.\\
+    \seticon{faBus}~\textbf{Bushaltestelle:} BG Unfallklinik (Linien 5, 13, 14, 17, 18, 19, X15)
+\fi
+
 %Spieleabend 1
 \ifml
-    \item[Board Game Night 1 -- Tuesday, October 1st \YEAR, Sand]~\\%, 19:00, Sand]~\\
+    \item[Board Game Night 1 -- Tuesday, April 1st \YEAR, 19:00 Uhr, Sand A104]~\\%, Sand]~\\
     We'd like to invite you to a board game night in relaxed atmosphere at the Sand.
     We'll provide some games as well as drinks and snacks (for a small donation).
     Even though our collection is growing steadily, we're more than happy if you bring along your own games!\\
     \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
 \else
-    \item[Spieleabend 1 -- Dienstag, 1. Oktober \YEAR, Sand]~\\%, 19:00 Uhr, Sand]~\\
+    \item[Spieleabend 1 -- Dienstag, 1. April \YEAR, 19:00 Uhr, Sand A104]~\\%,  Sand]~\\
+    Wir möchten dich zu einem kleinen Analog-Spieleabend mit guter Gesellschaft und entspannter Atmosphäre auf dem Sand einladen.
+    Für einige Spiele sowie Getränke und Knabberkram (gegen einen kleinen Obolus) sorgt die Fachschaft.
+    Wir freuen uns natürlich sehr, wenn du auch eigene Spiele mitbringst, obwohl unsere Sammlung schon beachtlich ist!\\
+    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
+\fi
+
+%Spieleabend 2 %TODO time
+\ifml
+    \item[Board Game Night 2 -- Wednesday, April 16th \YEAR, 19:00 Uhr, Sand A301]~\\%, Sand]~\\
+    We'd like to invite you to a board game night in relaxed atmosphere at the Sand.
+    We'll provide some games as well as drinks and snacks (for a small donation).
+    Even though our collection is growing steadily, we're more than happy if you bring along your own games!\\
+    \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
+\else
+    \item[Spieleabend 2 -- Mittwoch, 16. April \YEAR, 19:00 Uhr, Sand A301]~\\%, Sand]~\\
     Wir möchten dich zu einem kleinen Analog-Spieleabend mit guter Gesellschaft und entspannter Atmosphäre auf dem Sand einladen.
     Für einige Spiele sowie Getränke und Knabberkram (gegen einen kleinen Obolus) sorgt die Fachschaft.
     Wir freuen uns natürlich sehr, wenn du auch eigene Spiele mitbringst, obwohl unsere Sammlung schon beachtlich ist!\\
@@ -110,13 +136,13 @@
 
 %Flunkyball
 \ifml
-    \item[Flunkyball -- Wednesday, October 2nd \YEAR, 18:00, Sand]~\\
+    \item[Flunkyball -- Montag, April 14th \YEAR, 18:00 Uhr, Sand]~\\
     Fancy a round of flunkyball? Come along, grab a bottle and have fun!
     Perfect opportunity to switch off and meet new people.
     Teams can be formed spontaneously and you can get beer from us for a small donation.\\
     \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
 \else
-    \item[Flunkyball -- Mittwoch, 2. Oktober \YEAR, 18:00 Uhr, Sand]~\\
+    \item[Flunkyball -- Montag, 14. April \YEAR, 18:00 Uhr, Sand]~\\
     Lust auf 'ne Runde Flunkyball? Komm vorbei, schnapp dir 'ne Flasche und hab Spaß!
     Perfekte Gelegenheit, um abzuschalten und neue Leute kennenzulernen.
     Teams können spontan gebildet werden und Bier kannst du von uns gegen eine kleine Spende bekommen.\\
@@ -126,17 +152,20 @@
 % Nur damit die Seite richtig gebrochen wird.
 % TODO: Muss jedes jahr angepasst werden.
 % \ifbinfo \ifmaster \pagebreak  \fi \fi
+\ifmedinfo \ifmaster \pagebreak \fi \fi
+\ifinfo \ifmaster \iflehramt \else \pagebreak \fi \fi \fi
+\ifmedien \ifmaster \pagebreak \fi \fi
 
 %Wanderung 1
 \ifml
-\item[Hike 1 -- Saturday, October 5th \YEAR, 10:30, on the Neckarinsel (Neckar Island)]~\\
+\item[Hike 1 -- Saturday, April 5th \YEAR, on the Neckarinsel (Neckar Island)]~\\
 On a leisurely hike you will get to know not only your fellow students,
 but also a few lecturers and the worthwhile surroundings of Tübingen!
 % The meeting point is at the Neckarbrücke \emph{in front of the} restaurant \glqq Neckarmüller\grqq.\\
 The meeting point is on the Neckarinsel.\\
 \seticon{faBus}~\textbf{bus stop:} Neckarbrücke (lines 1--22)
 \else
-\item[Wanderung 1 -- Samstag, 5. Oktober \YEAR, 10:30 Uhr, auf der Neckarinsel]~\\
+\item[Wanderung 1 -- Samstag, 5. April \YEAR, auf der Neckarinsel]~\\
 Bei einer gemütlichen Wanderung lernt ihr neben euren Kommilitonen und Kommilitoninnen auch
 noch ein paar Dozierende und die sehenswerte Tübinger Umgebung kennen!
 % Der Treffpunkt ist bei der Neckarbrücke (\emph{vor} dem Gasthaus \glqq Neckarmüller\grqq).\\
@@ -144,43 +173,79 @@ Der Treffpunkt ist auf der Neckarinsel.\\
 \seticon{faBus}~\textbf{Bushaltestelle:} Neckarbrücke (Linien 1--22)
 \fi
 
-% Nur damit die Seite richtig gebrochen wird.
-% TODO: Muss jedes jahr angepasst werden.
-\ifmaster \ifinfo \iflehramt \else \pagebreak \fi \fi \fi
-\ifmaster \ifmedien \pagebreak \fi \fi
-\ifmaster \ifmedinfo \pagebreak \fi \fi
-\ifmaster \ifkogwiss \pagebreak \fi \fi
-
-% Kneipentour 1 % TODO Uhrzeit
+%Wanderung 2
 \ifml
-    \item[Pub Crawl 1 -- Tuesday, October 8th \YEAR]~\\
-    Tübingen is a town full of small pubs and bars that characterize the nightlife.
-    To calm down from the stress of this information-filled day, we'd like to invite you to go bar-hopping with us.
-    We'll divide up into small groups and visit the different bars in the historic town center.
-    Please bring enough cash, most places we will visit don't accept cards (\emph{none whatsoever}).
+    \item[Hike 2 -- Saturday, Mai 3rd \YEAR, on the Neckarinsel (Neckar Island)]~\\
+    Time for another hike! Join us for a relaxing stroll through the beautiful Tübingen countryside.
+    This is a great chance to enjoy nature, chat with fellow students, and maybe even meet some of your professors.
+    % The meeting point is at the Neckarbrücke \emph{in front of the} restaurant \glqq Neckarmüller\grqq.\\
+    The meeting point is on the Neckarinsel.\\
+    \seticon{faBus}~\textbf{bus stop:} Neckarbrücke (lines 1--22)
 \else
-    \item[Kneipentour 1 -- Dienstag, 8. Oktober \YEAR]~\\
-    Tübingen ist übersät mit kleinen Kneipen und Bars, die das Nachtleben maßgeblich bestimmen.
-    Um den Stress der ersten Veranstaltungen etwas sacken zu lassen, laden wir dich zu einer ausgiebigen Kneipentour ein,
-    bei der wir in Kleingruppen die verschiedenen Lokalitäten der Tübinger Altstadt besuchen.
-    Bitte bringe genügend Bargeld mit, man kann in fast keiner der Tübinger Bars mit EC-Karte zahlen! -- Volksbanken und Sparkassen finden sich bei Bedarf in der Stadt.
+    \item[Wanderung 2 -- Samstag, 3. Mai \YEAR, auf der Neckarinsel]~\\
+    Zeit für eine weitere Wanderung! Komm mit auf einen entspannten Spaziergang durch die schöne Umgebung Tübingens.
+    Bei einer gemütlichen Wanderung lernt ihr eure Kommilitonen und Kommilitoninnen
+    und vielleicht auch ein paar Dozierende kennen!
+    % Der Treffpunkt ist bei der Neckarbrücke (\emph{vor} dem Gasthaus \glqq Neckarmüller\grqq).\\
+    Der Treffpunkt ist auf der Neckarinsel.\\
+    \seticon{faBus}~\textbf{Bushaltestelle:} Neckarbrücke (Linien 1--22)
 \fi
 
 % Nur damit die Seite richtig gebrochen wird.
 % TODO: Muss jedes jahr angepasst werden.
-\ifbachelor \pagebreak \fi
+%\ifmaster \ifinfo \else \pagebreak \fi \fi
+\ifmaster \iflehramt \pagebreak \fi \fi
+%\ifmaster \ifmedien \pagebreak \fi \fi
+%\ifmaster \ifmedinfo \pagebreak \fi \fi
+\ifmaster \ifkogwiss \pagebreak \fi \fi
+
+% Kneipentour 1 % TODO Uhrzeit
+\ifml
+    \item[Pub Crawl 1 -- Friday, April 11th \YEAR, ca. 19:00 Uhr, Stiftskirche]~\\
+    Tübingen is a town full of small pubs and bars that characterize the nightlife.
+    To calm down from the stress of this information-filled day, we'd like to invite you to go bar-hopping with us.
+    We'll divide up into small groups and visit the different bars in the historic town center.
+    Please bring enough cash, most places we will visit don't accept cards (\emph{none whatsoever}). \\
+    \seticon{faBus}~\textbf{bus stop:} Neckarbrücke or Nonnenhaus (lines 1--21)
+\else
+    \item[Kneipentour 1 -- Freitag, 11. April \YEAR, ca. 19:00 Uhr, Stiftskirche]~\\
+    Tübingen ist übersät mit kleinen Kneipen und Bars, die das Nachtleben maßgeblich bestimmen.
+    Um den Stress der ersten Veranstaltungen etwas sacken zu lassen, laden wir dich zu einer ausgiebigen Kneipentour ein,
+    bei der wir in Kleingruppen die verschiedenen Lokalitäten der Tübinger Altstadt besuchen.
+    Bitte bringe genügend Bargeld mit, man kann in fast keiner der Tübinger Bars mit EC-Karte zahlen! -- Volksbanken und Sparkassen finden sich bei Bedarf in der Stadt.\\
+   \seticon{faBus}~\textbf{Bushaltestelle:} Neckarbrücke oder Nonnenhaus (Linien 1--21)
+\fi
+
+% Kneipentour 2 % TODO Uhrzeit
+\ifml
+\item[Pub Crawl 2 -- Tuesday, April 15th \YEAR, ca. 19:00 Uhr, Stiftskirche]~\\
+    Ready for round two? Join us for another pub crawl through Tübingen's best spots.
+    We'll split into smaller groups again and visit the different bars in the historic town center.
+    Please bring enough cash, most places we will visit don't accept cards (\emph{none whatsoever}).\\
+   \seticon{faBus}~\textbf{bus stop:} Neckarbrücke or Nonnenhaus (lines 1--21)
+\else
+\item[Kneipentour 2 -- Dienstag, 15. April \YEAR, ca. 19:00 Uhr, Stiftskirche]~\\
+    Bereit für Runde Zwei? Komm mit auf eine weitere Kneipentour durch die besten Kneipen Tübingens.
+    Wir werden uns wieder in kleinere Gruppen aufteilen und die verschiedenen Bars in der Altstadt besuchen.
+    Bitte bringe genügend Bargeld mit, man kann in fast keiner der Tübinger Bars mit EC-Karte zahlen! -- Volksbanken und Sparkassen finden sich bei Bedarf in der Stadt.\\
+   \seticon{faBus}~\textbf{Bushaltestelle:} Neckarbrücke oder Nonnenhaus (Linien 1--21)
+\fi
+
+% Nur damit die Seite richtig gebrochen wird.
+% TODO: Muss jedes jahr angepasst werden.
+%\ifbachelor \pagebreak \fi
 
 % Semestereröffnung
 \ifml
     \vspace{-2.07182\baselineskip} \ \\ % to counteract the different spacing of the parbox in the line below. Remove this line if you remove the parbox and vspace in the line below
-    \item[\parbox{\linewidth}{Semester Opening by Faculty -- Thursday, October 10th \YEAR, 16:15,\\ Audimax, Neue Aula}]\ \vspace{.355\baselineskip} \\ % parbox and vspace since the line is too long
+    \item[\parbox{\linewidth}{Semester Opening by Faculty -- Friday, April 11th \YEAR, 16:15,\\ Audimax, Neue Aula}]\ \vspace{.355\baselineskip} \\ % parbox and vspace since the line is too long
     This department information event with presentation of all elective courses in the winter
     semester is especially useful if you are new to Tübingen and want to get a first impression
     of the professors and courses you will be dealing with in the future.\\
     \seticon{faBus}~\textbf{bus stop:} Uni/Neue Aula or Hölderlinstraße
 \else
     \vspace{-2.07182\baselineskip} \ \\ % to counteract the different spacing of the parbox in the line below. Remove this line if you remove the parbox and vspace in the line below
-    \item[\parbox{\linewidth}{Semestereröffnung Fachbereich -- Donnerstag, 10. Oktober \YEAR, 16:15 Uhr,\\ Audimax, Neue Aula}]\ \vspace{.355\baselineskip} \\ % parbox and vspace since the line is too long
+    \item[\parbox{\linewidth}{Semestereröffnung Fachbereich -- Freitag, 11. April \YEAR, 16:15 Uhr,\\ Audimax, Neue Aula}]\ \vspace{.355\baselineskip} \\ % parbox and vspace since the line is too long
     Informationsveranstaltung des Fachbereichs mit Vorstellung aller
     Wahlveranstaltungen im Wintersemester.
     \ifbachelor
@@ -193,24 +258,9 @@ Der Treffpunkt ist auf der Neckarinsel.\\
     \seticon{faBus}~\textbf{Bushaltestelle:} Uni/Neue Aula oder Hölderlinstraße
 \fi
 
-%Spieleabend 2 %TODO time
-\ifml
-    \item[Board Game Night 2 -- Thursday, October 10th \YEAR, Sand]~\\%, 19:00, Sand]~\\
-    We'd like to invite you to a board game night in relaxed atmosphere at the Sand.
-    We'll provide some games as well as drinks and snacks (for a small donation).
-    Even though our collection is growing steadily, we're more than happy if you bring along your own games!\\
-    \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
-\else
-    \item[Spieleabend 2 -- Donnerstag, 10. Oktober \YEAR, Sand]~\\%, 19:00 Uhr, Sand]~\\
-    Wir möchten dich zu einem kleinen Analog-Spieleabend mit guter Gesellschaft und entspannter Atmosphäre auf dem Sand einladen.
-    Für einige Spiele sowie Getränke und Knabberkram (gegen einen kleinen Obolus) sorgt die Fachschaft.
-    Wir freuen uns natürlich sehr, wenn du auch eigene Spiele mitbringst, obwohl unsere Sammlung schon beachtlich ist!\\
-    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
-\fi
-
 % Frühstück
 \ifbachelor
-    \item[Frühstück -- Freitag, 11. Oktober \YEAR, 10:00 Uhr, Mensa Morgenstelle]\ \\
+    \item[Frühstück -- Freitag, 11. April \YEAR, 10:00 Uhr, Mensa Morgenstelle]\ \\
     Wir laden dich an diesem Morgen zu einem gemütlichen Frühstück ein! Dabei erfährst du einiges über die Uni, die Fachschaft und was dich in den nächsten Monaten erwartet -- auch im Gespräch mit älteren Studierenden.
     Danach machen wir eine Führung über die Morgenstelle, damit du die wichtigsten Räume und Hörsäle kennenlernst.
     Wenn du Lust hast, kannst du anschließend ab 11:45 Uhr das Mensaessen ausprobieren.\\
@@ -233,168 +283,127 @@ Der Treffpunkt ist auf der Neckarinsel.\\
 
 % Grillen 1
 \ifml
-    \item[BBQ 1 -- Saturday, October 12th \YEAR, 18:30, in the garden of the Sand]~\\
+    \item[BBQ 1 -- Saturday, April 12th \YEAR, in the garden of the Sand]~\\
     You're not in the mood for cooking this evening? Fear not!
     The student council invites you for a BBQ. Bring whatever you want to put on the grill,
     please also bring your own plates and cutlery. The garden has enough space for stuff like volleyball, football etc. as well.\\
     \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
 \else
-    \item[Grillen 1 -- Samstag, 12. Oktober \YEAR, 18:30 Uhr, im Garten des Sandes]~\\
+    \item[Grillen 1 -- Samstag, 12. April \YEAR, im Garten des Sandes]~\\
     Du hast keinen Bock auf Kochen? Dann bist du hier genau richtig! In geselliger Runde wird die Fachschaft mit dir grillen.
     Bring dazu mit, was auch immer du zum Grillen brauchst, ein großer Gasgrill wartet auf dich. Vergiss bitte auch nicht, dein eigenes Besteck und Geschirr einzupacken!\\
     Auf dem Sand ist es auch möglich Volleyball, Fußball, usw. zu spielen. Wir freuen uns auf dich!\\
     \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
 \fi
 
-% Erste Vorlesung
-\ifbachelor
-    \item[Erste Vorlesung -- Montag, 14. Oktober \YEAR, \ifwintersemester 8:00 Uhr, \else 10:00 Uhr, \fi Morgenstelle]~\\
-    Deine erste Vorlesung beginnt um
-    \ifwintersemester 8:00 Uhr -- Du hast „Mathematik für Informatik 1“  \fi
-    \ifsommersemester 10:00 Uhr -- Du hast „Mathematik für Informatik 2“  \fi
-    bei \Matheprof.
-    Alles, was du heute (und in Zukunft) benötigst: persönlichen Wachmacher, einen Stift, einen Block und den Studierendenausweis.\\
-    \seticon{faBus}~\textbf{Bushaltestelle:} BG Unfallklinik (Linien 5, 13, 14, 17, 18, 19, X15)
-\fi
-
-% Kneipentour 2 % TODO Uhrzeit
-\ifml
-\item[Pub Crawl 2 -- Monday, October 14th \YEAR]~\\
-    Ready for round two? Join us for another pub crawl through Tübingen's best spots.
-    We'll split into smaller groups again and visit the different bars in the historic town center.
-    Please bring enough cash, most places we will visit don't accept cards (\emph{none whatsoever}).
-\else
-\item[Kneipentour 2 -- Montag, 14. Oktober \YEAR]~\\
-    Bereit für Runde Zwei? Komm mit auf eine weitere Kneipentour durch die besten Kneipen Tübingens.
-    Wir werden uns wieder in kleinere Gruppen aufteilen und die verschiedenen Bars in der Altstadt besuchen.
-    Bitte bringe genügend Bargeld mit, man kann in fast keiner der Tübinger Bars mit EC-Karte zahlen! -- Volksbanken und Sparkassen finden sich bei Bedarf in der Stadt.
-\fi
-
-% Filmeabends % TODO date & time % TODO invite ML, movie language?
-\ifml
-    \item[Movie Night -- Tuesday, October 15th \YEAR, 19:00, Sand]~\\%, 19:00, Sand]~\\
-    % Falls im Wintersemester ein Filmeabend veranstaltet wird, sollte in der Einladung erwähnt werden, auf welcher
-    % Sprache der Film gezeigt wird.
-    In the evening, we're hosting a movie night, and we'd love for you to join us!
-    It'll be a great way to unwind after your first days of student life.
-    Bring your new friends and your favorite snacks, and let's go!
-    Drinks will be provided for a small donation.\\
-    \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
-\else
-    \item[Filmeabend -- Dienstag, 15. Oktober, 19:00 Uhr, Sand]~\\
-    Am Abend veranstalten wir unseren Filmeabend und wir laden euch herzlich dazu ein!\\
-    Schaut mit uns einen Film an und entspannt euch nach euren ersten Tagen im Studileben.
-    Bringt eure neuen Freunde, Freundinnen und eure Lieblingssnacks mit und los geht's!\\
-    Für Getränke ist gegen eine kleine Spende gesorgt.\\
-    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
-\fi
-
-% Nur damit die Seite richtig gebrochen wird.
-% TODO: Muss jedes jahr angepasst werden.
-\ifbachelor \pagebreak \fi
-\ifmaster \ifinfo \iflehramt \else \pagebreak \fi \fi \fi
-\ifmaster \ifmedien \pagebreak \fi \fi
-\ifmaster \ifmedinfo \pagebreak \fi \fi
-\ifmaster \ifkogwiss \pagebreak \fi \fi
-
-% Kastenlauf
-\ifml
-\item[Crate Run -- Wednesday, October 16th \YEAR, Rewe West]~\\
-    Please join us on our crate run.
-    Each team of two to four will have a crate (can be purchased on site).
-    The goal is to have emptied the crate at the finish line.
-    On your tour you will have to visit a few stops.
-    We don't force anyone to drink, you are also welcome to drink non-alcoholic beer, soft drinks, or whatever you like.
-    So if you're up for meeting new people, good vibes, and a little sporty drinking, feel free to drop by! \\
-    \seticon{faBus}~\textbf{bus stop:} Schleifmühleweg (bus lines 11 \& 12)
-\else
-\item[Kastenlauf -- Mittwoch, 16. Oktober \YEAR, Rewe Weststadt]~\\
-    Wir laden euch herzlich zu unserem Kastenlauf ein.
-    Jedes Zweier- bis Viererteam hat einen Kasten (kann vor Ort gekauft werden).
-    Das Ziel ist es, an der Ziellinie den Kasten leergetrunken zu haben.
-    Auf eurer Tour müsst ihr dabei verschiedene Stationen besuchen.
-    Unser Motto: Wer nicht wankt, der nicht gewinnt!\footnote{Wir zwingen niemanden zum Saufen, ihr dürft auch gerne alkoholfreies Bier, Softdrinks, etc. trinken.}
-    Wer also Lust hat auf neue Leute, gute Laune und ein wenig sportliches Trinken, kann gerne vorbeischauen! \\
-    \seticon{faBus}~\textbf{Bushaltestelle:} Schleifmühleweg (Linien 11 \& 12)
-\fi
-
-% Akademischer Spieleabend %TODO time
-\ifml
-    \item[Academic Game Night -- Thursday, October 17th \YEAR, Sand]~\\%, 19:00, Sand]~\\
-    This game night is a bit different. You can expect to find drinking games here,
-    but there are also non-alcoholic drinks for those who prefer to stick to water or soft drinks.\\
-    \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
-\else
-    \item[Akademischer Spieleabend -- Donnerstag, 17. Oktober \YEAR, Sand]~\\%, 19:00 Uhr, Sand]~\\
-    Im Unterscheid zum "`normalen"' Spieleabend stehen hier vor allem Trinkspiele auf dem Programm.
-    Natürlich gibt es aber auch alkoholfreie Getränke.\\
-    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
-\fi
-
-% Nur damit die Seite richtig gebrochen wird.
-% TODO: Muss jedes jahr angepasst werden.
-% \ifmaster \ifbinfo \else \ifml \else \pagebreak \fi \fi \fi
-
 % Grillen 2
 \ifml
-    \item[BBQ 2 -- Saturday, October 19th \YEAR, 18:30, in the garden of the Sand]~\\
+    \item[BBQ 2 -- Sunday, Mai 25th \YEAR, in the garden of the Sand]~\\
     Because it's so nice, we'll have another barbecue!
     Bring whatever you'd like to grill, and don’t forget your own plates and cutlery!\\
     You can also play volleyball, football, and more in the garden. We’re looking forward to seeing you there!\\
     \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
 \else
-    \item[Grillen 2 -- Samstag, 19. Oktober \YEAR, 18:30 Uhr, im Garten des Sandes]~\\
+    \item[Grillen 2 -- Sonntag, 25. Mai \YEAR, im Garten des Sandes]~\\
     Und weils so schön ist, grillen wir nochmal!
     Bring mit, was auch immer du grillen möchtest. Eigenes Besteck und Geschirr bitte nicht vergessen!\\
     Auf dem Sand ist es auch möglich Volleyball, Fußball, usw. zu spielen. Wir freuen uns auf dich!\\
     \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
 \fi
 
-% Capture the Flag
+% Filmeabends % TODO date & time % TODO invite ML, movie language?
+%\ifml
+%   \item[Movie Night -- Tuesday, October 15th \YEAR, 19:00, Sand]~\\%, 19:00, Sand]~\\
+%    % Falls im Wintersemester ein Filmeabend veranstaltet wird, sollte in der Einladung erwähnt werden, auf welcher
+%    % Sprache der Film gezeigt wird.
+%    In the evening, we're hosting a movie night, and we'd love for you to join us!
+%    It'll be a great way to unwind after your first days of student life.
+%    Bring your new friends and your favorite snacks, and let's go!
+%    Drinks will be provided for a small donation.\\
+%    \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
+%\else
+%    \item[Filmeabend -- Dienstag, 15. Oktober, 19:00 Uhr, Sand]~\\
+%    Am Abend veranstalten wir unseren Filmeabend und wir laden euch herzlich dazu ein!\\
+%    Schaut mit uns einen Film an und entspannt euch nach euren ersten Tagen im Studileben.
+%    Bringt eure neuen Freunde, Freundinnen und eure Lieblingssnacks mit und los geht's!\\
+%    Für Getränke ist gegen eine kleine Spende gesorgt.\\
+%    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
+%\fi
+
+% Nur damit die Seite richtig gebrochen wird.
+% TODO: Muss jedes jahr angepasst werden.
+%\ifbachelor \pagebreak \fi
+%\ifmaster \ifinfo \iflehramt \else \pagebreak \fi \fi \fi
+\ifmaster \ifmedien \pagebreak \fi \fi
+%\ifmaster \ifmedinfo \pagebreak \fi \fi
+\ifmaster \ifkogwiss \pagebreak \fi \fi
+
+% Kastenlauf
 \ifml
-    \item[Capture the Flag -- Sunday, October 20th \YEAR, 14:00, Sand]~\\
-    We play a round of Capture the Flag together in real life.
-    A wonderful opportunity to test our teamwork skills and meet new friends (or enemies).\\
-    \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
+\item[Crate Run -- Wednesday, April 23rd \YEAR]~\\ % , Rewe West]~\\
+    Please join us on our crate run.
+    Each team of two to four will have a crate (can be purchased on site).
+    The goal is to have emptied the crate at the finish line.
+    On your tour you will have to visit a few stops.
+    We don't force anyone to drink, you are also welcome to drink non-alcoholic beer, soft drinks, or whatever you like.
+    So if you're up for meeting new people, good vibes, and a little sporty drinking, feel free to drop by! 
+    %\seticon{faBus}~\textbf{bus stop:} Schleifmühleweg (bus lines 11 \& 12)
 \else
-    \item[Capture the Flag -- Sonntag, 20. Oktober \YEAR, 14:00 Uhr, Sand]~\\
-    Wir spielen gemeinsam eine Runde real-life Capture the Flag.
-    Eine wunderbare Gelegenheit, unsere Teamwork-Fähigkeiten zu testen und neue Freunde (oder Feinde) kennenzulernen.\\
-    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
+\item[Kastenlauf -- Mittwoch, 23.April \YEAR]~\\ %, Rewe Weststadt]~\\
+    Wir laden euch herzlich zu unserem Kastenlauf ein.
+    Jedes Zweier- bis Viererteam hat einen Kasten (kann vor Ort gekauft werden).
+    Das Ziel ist es, an der Ziellinie den Kasten leergetrunken zu haben.
+    Auf eurer Tour müsst ihr dabei verschiedene Stationen besuchen.
+    Unser Motto: Wer nicht wankt, der nicht gewinnt!\footnote{Wir zwingen niemanden zum Saufen, ihr dürft auch gerne alkoholfreies Bier, Softdrinks, etc. trinken.}
+    Wer also Lust hat auf neue Leute, gute Laune und ein wenig sportliches Trinken, kann gerne vorbeischauen! 
+    %\seticon{faBus}~\textbf{Bushaltestelle:} Schleifmühleweg (Linien 11 \& 12)
 \fi
 
-%Wanderung 2
-\ifml
-    \item[Hike 2 -- Saturday, October 26th \YEAR, 10:30, on the Neckarinsel (Neckar Island)]~\\
-    Time for another hike! Join us for a relaxing stroll through the beautiful Tübingen countryside.
-    This is a great chance to enjoy nature, chat with fellow students, and maybe even meet some of your professors.
-    % The meeting point is at the Neckarbrücke \emph{in front of the} restaurant \glqq Neckarmüller\grqq.\\
-    The meeting point is on the Neckarinsel.\\
-    \seticon{faBus}~\textbf{bus stop:} Neckarbrücke (lines 1--22)
-\else
-    \item[Wanderung 2 -- Samstag, 26. Oktober \YEAR, 10:30 Uhr, auf der Neckarinsel]~\\
-    Zeit für eine weitere Wanderung! Komm mit auf einen entspannten Spaziergang durch die schöne Umgebung Tübingens.
-    Bei einer gemütlichen Wanderung lernt ihr eure Kommilitonen und Kommilitoninnen
-    und vielleicht auch ein paar Dozierende kennen!
-    % Der Treffpunkt ist bei der Neckarbrücke (\emph{vor} dem Gasthaus \glqq Neckarmüller\grqq).\\
-    Der Treffpunkt ist auf der Neckarinsel.\\
-    \seticon{faBus}~\textbf{Bushaltestelle:} Neckarbrücke (Linien 1--22)
-\fi
+% Akademischer Spieleabend %TODO time
+%\ifml
+%    \item[Academic Game Night -- Thursday, October 17th \YEAR, Sand]~\\%, 19:00, Sand]~\\
+%    This game night is a bit different. You can expect to find drinking games here,
+%    but there are also non-alcoholic drinks for those who prefer to stick to water or soft drinks.\\
+%    \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
+%\else
+%    \item[Akademischer Spieleabend -- Donnerstag, 17. Oktober \YEAR, Sand]~\\%, 19:00 Uhr, Sand]~\\
+%    Im Unterscheid zum "`normalen"' Spieleabend stehen hier vor allem Trinkspiele auf dem Programm.
+%    Natürlich gibt es aber auch alkoholfreie Getränke.\\
+%    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
+%\fi
+
+% Nur damit die Seite richtig gebrochen wird.
+% TODO: Muss jedes jahr angepasst werden.
+%\ifmaster \ifbinfo \else \ifml \else \pagebreak \fi \fi \fi
+\ifmaster \iflehramt \pagebreak \fi \fi
+
+%% Capture the Flag
+%\ifml
+%    \item[Capture the Flag -- Sunday, October 20th \YEAR, 14:00, Sand]~\\
+%    We play a round of Capture the Flag together in real life.
+%    A wonderful opportunity to test our teamwork skills and meet new friends (or enemies).\\
+%    \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
+%\else
+%    \item[Capture the Flag -- Sonntag, 20. Oktober \YEAR, 14:00 Uhr, Sand]~\\
+%    Wir spielen gemeinsam eine Runde real-life Capture the Flag.
+%    Eine wunderbare Gelegenheit, unsere Teamwork-Fähigkeiten zu testen und neue Freunde (oder Feinde) kennenzulernen.\\
+%    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
+%\fi
 
 %Clubhausfest
 \ifml
-    \item[Clubhausfest -- Thursday, October 31st \YEAR, 21:00, Clubhaus]\ \\
+    \item[Clubhausfest -- Thursday, May 22nd \YEAR, 21:00, Clubhaus]\ \\
     Every thursday during the lecture period, a different student body or group of students organizes the "`Clubhaus Fest"' in
     the Clubhaus, which locates directly opposite of the new auditorium. Today the attendance is particularly worthwhile, because
-    the student councils of computer science, cognitive science, psychology, neurobiology and geography are hosting the event! \\
+    the student councils of computer science, cognitive science and psychology are hosting the event! \\
     No registration necessary.\\
     \seticon{faBus}~\textbf{bus stop:} Uni/Neue Aula or Hölderlinstraße
 \else
-    \item[Clubhausfest -- Donnerstag, 31. Oktober \YEAR, 21:00 Uhr, Clubhaus]\ \\
+    \item[Clubhausfest -- Donnerstag, 22. Mai \YEAR, 21:00 Uhr, Clubhaus]\ \\
     Während der Vorlesungszeit richtet jeden Donnerstag eine andere Fachschaft oder studentische Gruppierung das Clubhausfest
     im Clubhaus, direkt gegenüber der Neuen Aula, aus. Heute lohnt sich der Besuch jedoch ganz besonders, denn die Fachschaften
-    Informatik, Kogni, Psychologie, Neurobiologie und Geographie sind Gastgeber! % \\ % TODO line break wieder einfügen: Eigentlich wäre hier ein line break schöner, aber im WS24 würde dann eine einzelne Zeile auf die nächste Seite kommen
-    Keine Anmeldung nötig.\\
+    Informatik, Kogni und Psychologie sind Gastgeber!  %\\ TODO linebreak einkommentieren, falls nur noch fsi/k Veranstalter, sonst wäre ein einzelner Satz auf der nächsten Seite. 
+    Keine Anmeldung nötig.\\ 
     %Das anfängliche Chaos des Vorlesungsbeginns hat sich gelegt und auch an diesem Donnerstag findet das Clubhausfest statt.\\
     \seticon{faBus}~\textbf{Bushaltestelle:} Uni/Neue Aula oder Hölderlinstraße
 \fi
@@ -403,14 +412,15 @@ Der Treffpunkt ist auf der Neckarinsel.\\
 % TODO: Muss jedes jahr angepasst werden.
 % \ifml \pagebreak \fi
 
-\ifml
-   % TODO?
-\else
-   \item[Erstihütte -- Freitag, 01. November bis Sonntag, 03. November \YEAR]~\\
-   Vom 01. bis 03. November fahren wir auf die Erstihütte in Kalkweil.
-   Euch erwartet ein geselliges Programm und ein entspanntes Miteinander.
-   Weitere Informationen bezüglich Anmeldung folgen.
-\fi
+%% Erstihütte
+%\ifml
+ % % TODO?
+%\else
+%  \item[Erstihütte -- Freitag, 01. November bis Sonntag, 03. November \YEAR]~\\
+%   Vom 01. bis 03. November fahren wir auf die Erstihütte in Kalkweil.
+%   Euch erwartet ein geselliges Programm und ein entspanntes Miteinander.
+%   Weitere Informationen bezüglich Anmeldung folgen.
+%\fi
 
 %Schnuppersitzung % TODO date & time
 \ifkogwiss
@@ -425,7 +435,7 @@ Der Treffpunkt ist auf der Neckarinsel.\\
     % \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
 \else
     \ifml
-        \item[fsi trial meeting -- TBA (regular meetings: Thursdays, 18:30, Sand, A104)]~\\%Thursday, May 18th \YEAR, 18:30, Sand]~\\
+        \item[fsi trial meeting -- Thursday, May 8th \YEAR, 18:30, Sand]~\\ %TBA (regular meetings: Thursdays, 18:30, Sand, A104)]~\\
         Hopefully, we were able to arouse your interest in student council work with our events.
         But we do much more than just first-year events, we represent the students in committees,
         we are contact persons, provide infrastructure and tools and much more.
@@ -434,7 +444,7 @@ Der Treffpunkt ist auf der Neckarinsel.\\
         No registration necessary.\\
         \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
     \else
-        \item[Schnuppersitzung der fsi -- TBA (reguläre Sitzungen: Donnerstags, 18:30, A104, Sand)]~\\%Donnerstag, 18. Mai \YEAR, 18:30 Uhr, Sand]~\\
+        \item[Schnuppersitzung der fsi -- Donnerstag, 8. Mai \YEAR, 18:30 Uhr, Sand]~\\ %TBA (reguläre Sitzungen: Donnerstags, 18:30, A104, Sand)]~\\
         Hoffentlich konnten wir mit unseren Veranstaltungen euer Interesse an Fachschaftsarbeit wecken.
         Wir machen aber noch viel mehr als nur Ersti-Veranstaltungen, wir vertreten die Studierenden in Gremien,
         sind Ansprechpartner, stellen Infrastruktur und Tools bereit und vieles mehr.
@@ -445,27 +455,25 @@ Der Treffpunkt ist auf der Neckarinsel.\\
     \fi
 \fi
 
-
-
-
-
-
-% %Stadtrallye
-% \ifml
-%     \item[City Rally -- Friday, October 20h \YEAR]~\\%, ca. 16:00]~\\
-%     On this evening, you can participate in a team-based scavenger hunt across the city,
-%     where you will get to know interesting, beautiful as well as disturbing spots within Tübingen.
-%     As a side effect, you will hopefully get to know your new home town a bit better and make new friends.
-% \else
-%     \item[Stadtrallye -- Freitag, 20. Oktober \YEAR]~\\%, ca. 16:00 Uhr]~\\
-%     Bei der Stadtrallye lassen wir dich und deine Kommilitonen und Kommilitoninnen gegeneinander in Teams antreten.
-%     Dabei werdet ihr interessante, schöne und verstörende Ecken Tübingens kennenlernen.
-% \fi
+%Stadtrallye / Abenteuer-Schnitzeljagd
+ \ifml
+     \item[scavenger-hunt -- Monday, April 14th \YEAR, 14:00, Stiftskirche]~\\
+     On this evening, you can participate in a team-based scavenger hunt across the city,
+     where you will get to know interesting and beautiful spots within Tübingen.
+     As a side effect, you will hopefully get to know your new home town a bit better and make new friends.
+   \seticon{faBus}~\textbf{bus stop:} Neckarbrücke or Nonnenhaus (lines 1--21)
+ \else
+     \item[Abenteuer-Schnitzeljagd -- Montag, 14. April \YEAR, 14:00 Uhr, Stiftskirche]~\\
+     Bei der Schnitzeljagd lassen wir dich und deine Kommilitonen und Kommilitoninnen gegeneinander in Teams antreten.
+     Dabei werdet ihr interessante und schöne Ecken Tübingens kennenlernen.\\
+   \seticon{faBus}~\textbf{Bushaltestelle:} Neckarbrücke oder Nonnenhaus (Linien 1--21)
+ \fi
 
 % Nur damit die Seite richtig gebrochen wird.
 % TODO: Muss jedes jahr angepasst werden.
 % \ifmaster \iflehramt \pagebreak  \fi \fi
 
+%%Lehrstuhlvorstellung
 %\ifkogwiss
 %    \item[Vorstellung der Lehrstühle -- Montag, 17. Oktober \YEAR, 17:00 Uhr und online]\ \\
 %    Hier stellen sich die kognitionswissenschaftlichen Lehrstühle (also die verschiedenen Forschungsbereiche der Professoren) vor. Dies ist super um einen Überblick zu bekommen, was die Kognitionswissenschaft alles beinhaltet und um erste Eindrücke von den Profs zu bekommen. Auch die Fachschaft stellt sich dir hier erstmals vor. %Danach gibt es noch Gelegenheit, mit der Fachschaft ein Glas Milch trinken zu gehen.
@@ -485,7 +493,6 @@ Der Treffpunkt ist auf der Neckarinsel.\\
 %    \seticon{faBus}~\textbf{Bushaltestelle:} Linie 2, Sand Drosselweg (Rest ausgeschildert)
 %    Falls sich auf Grund der aktuellen Situation Details ändern sollten, findest du weitere Infos auf der Website \url{https://www.fs-kogni.uni-tuebingen.de}.
 %\fi
-
 
 %\ifkogwiss
 % Bus-Schnitzeljagd, neu im WS19/20

--- a/stundenplaene/stpl_bioinfo-bsc_SS.tex
+++ b/stundenplaene/stpl_bioinfo-bsc_SS.tex
@@ -6,16 +6,16 @@ Semester neben den Informatik- und Biochemie-Vorlesungen auch eine gute Portion 
         \begin{tabular}{|c|c|c|c|c|c|}
         \hline
         Zeit     & Montag        & Dienstag                 & Mittwoch      & Donnerstag               & Freitag            \\ \hline
-        08 -- 09 &               &                          &               &                          &                    \\ \hline
-        09 -- 10 &               &                          &               &                          &                    \\ \hline
+        08 -- 09 &               	&                          &               &                          &                    \\ \hline
+        09 -- 10 &               	&                          &               &                          &                    \\ \hline
         10 -- 11 & Mathematik II &                          & Mathematik II &                          & Biochemie          \\ \cline{1-1} \cline{3-3} \cline{5-5}
         11 -- 12 & (\Matheprof)  &                          & (\Matheprof)  & Biochemie                & (Prof. Nürnberger) \\ \hline
-        12 -- 13 &               &                          &               &                          &                    \\ \cline{1-3} \cline{5-6}
-        13 -- 14 &               &                          & Mathe         &Einf. in die Bioinformatik\footnotemark &                    \\ \cline{1-3} \cline{5-6}
-        14 -- 15 &               & Praktische Informatik II & Rechenzentrum & Praktische Informatik II &                    \\ \cline{1-2} \cline{6-6}
-        15 -- 16 &               & (\Infoprof)              & (ab 24.04.)   & (\Infoprof)              &                    \\ \cline{1-3} \cline{5-6}
-        16 -- 17 &               &                          &               &                          &                    \\ \cline{1-3} \cline{5-6}
-        17 -- 18 &               &                          &               &                          &                    \\ \hline
+        12 -- 13 &              	 	&                          &               &                          &                    \\ \hline
+        13 -- 14 &               	&                          &          &Einf. in die Bioinformatik\footnotemark &                    \\ \cline{1-4} \cline{5-6}
+        14 -- 15 &              		 & Praktische Informatik II & Mathe  & Praktische Informatik II &                    \\ \cline{1-2} \cline{6-6}
+        15 -- 16 &               	& (\Infoprof)              &  Rechenzentrum  & (\Infoprof)              &                    \\ \cline{1-3} \cline{5-6}
+        16 -- 17 &               	&                          &  (ab 23.04.) &                          &                    \\ \cline{1-3} \cline{5-6}
+        17 -- 18 &               	&                          &               &                          &                    \\ \hline
         %18 -- 19 &               &                          &               &                          &                    \\ \cline{1-1} \cline{3-6}
         %19 -- 20 &               &                          &               &                          &                    \\ \hline
         \end{tabular}% <- this one aswell
@@ -33,11 +33,13 @@ wobei auch Tutorinnen und Tutoren anwesend sein werden. Die Teilnahme am Rechenz
 
 \textbf{Info 2}:\\
 Vollständiger Name: Praktische Informatik 2: Imperative und objektorientierte Programmierung\\
-Dieses Semester wird die Vorlesung wieder in Präsenz im Hörsaal N7 auf der Morgenstelle stattfinden.
-Zusätzlich werden Tutorien in Präsenz stattfinden.
+Dieses Semester wird die Vorlesung im Hörsaal N7 auf der Morgenstelle stattfinden.
+Zusätzlich werden Tutorien stattfinden.
 Die Zeiten für die Tutorien werden innerhalb der ersten Woche in den Vorlesungen bekannt gegeben.\\
 % Es wird für die Mathe II und die Info II auch noch freiwillige Zusatz-Tutorium und Einführungskurse geben.\\
 
 \textbf{üBK}:\\
 Im Studienplan wird empfohlen übK\footnote{überfachlich berufsfeldorientierte Kompetenzen, in Zukunft auch Liberal Education genannt}
 mit (insgesamt) 3-6 LP zu belegen. Hier ist dir völlig freigestellt was du belegst, solange es mit ECTS Punkten versehen, benotet und kein Sport ist.\\
+
+\pagebreak

--- a/stundenplaene/stpl_informatik-bsc.tex
+++ b/stundenplaene/stpl_informatik-bsc.tex
@@ -16,17 +16,17 @@ Alles weitere erfährst du bei eurer fachspezifischen Begrüßung.
 \begin{center}
 	\begin{tabular}{|c|c|c|c|c|c|}
 	\hline
-	 Zeit     &    Montag                    & Dienstag          & Mittwoch          	& Donnerstag 			& Freitag		\\ \hline\hline
-	 08 -- 09 &    Mathematik I              &                   & Mathematik I      	&  				&			\\ \cline{1-1} \cline{3-3} \cline{5-6} 
-	 09 -- 10 &    (\Matheprof)              &                   & (\Matheprof) 		&  				&			\\ \hline
-	 10 -- 11 &    Techn. Informatik I (TI I)&                   &                   	&  				&			\\ \cline{1-1} \cline{3-6}
-	 11 -- 12 &    (Prof. Zell)		 &                   &                   	&  				&			\\ \hline
-	 12 -- 13 &                              &                   &  			&  				&			\\ \cline{1-3} \cline{3-6}
-	 13 -- 14 &                              &                   & TI I (Prof. Zell)	& 				&			\\ \hline
-	 14 -- 15 &                              & Informatik I      &                 		&  Informatik I 		&			\\ \cline{1-2} \cline{4-4} \cline{6-6}
-	 15 -- 16 &                              & (\Infoprof)       &	                   	&  (\Infoprof) 			&			\\ \hline
-	 16 -- 17 &                              &                   &                   	&  				&			\\ \hline
-	 17 -- 18 &                              &                   &                   	&  				&			\\ \hline
+	 Zeit        &    Montag                         & Dienstag          & Mittwoch          	& Donnerstag 		& Freitag		\\ \hline\hline
+	 08 -- 09 &    Mathematik I                 &                   	& Mathematik I      	&  				&			\\ \cline{1-1} \cline{3-3} \cline{5-6} 
+	 09 -- 10 &    (\Matheprof)                 &                   	& (\Matheprof) 		&  				&			\\ \hline
+	 10 -- 11 &    Techn. Informatik I (TI I)&                   	&                   		&  				&			\\ \cline{1-1} \cline{3-6}
+	 11 -- 12 &    (Prof. Zell)		          &                  	&                   		&  				&			\\ \hline
+	 12 -- 13 &                              		&                   	&  				&  				&			\\ \cline{1-3} \cline{3-6}
+	 13 -- 14 &                              		&                   	& TI I (Prof. Zell)		& 				&			\\ \hline
+	 14 -- 15 &                              		& Informatik I     	&                 		&  Informatik I 		&			\\ \cline{1-2} \cline{4-4} \cline{6-6}
+	 15 -- 16 &                              		& (\Infoprof)       	&	                   		&  (\Infoprof) 		&			\\ \hline
+	 16 -- 17 &                             		&                   	&                   		&  				&			\\ \hline
+	 17 -- 18 &                              		&                   	&                   		&  				&			\\ \hline
 	\end{tabular}
 
 \end{center}

--- a/stundenplaene/stpl_informatik-bsc_SS.tex
+++ b/stundenplaene/stpl_informatik-bsc_SS.tex
@@ -6,18 +6,18 @@ Semester neben der Informatikvorlesung auch eine gute Portion Mathe.
     \resizebox{\textwidth}{!}{
     \begin{tabular}{|c|c|c|c|c|c|}
        \hline
-       Zeit     & Montag                   & Dienstag                   & Mittwoch      & Donnerstag               & Freitag \\ \hline
-       08 -- 09 &                          & Technische Informatik II   &               &                          &         \\ \cline{1-2} \cline{4-6}
-       09 -- 10 &                          & (Prof. Menth)              &               &                          &         \\ \hline
-       10 -- 11 & Mathematik II            &                            & Mathematik II &                          &         \\ \cline{1-1} \cline{3-3} \cline{5-6}
-       11 -- 12 & (\Matheprof)             &                            & (\Matheprof)  &                          &         \\ \hline
-       12 -- 13 &                          &                            &               &                          &         \\ \cline{1-3} \cline{5-6}
-       13 -- 14 &                          &                            & Mathe         &                          &         \\ \cline{1-3} \cline{5-6}
-       14 -- 15 &                          & Praktische Informatik II   & Rechenzentrum & Praktische Informatik II &         \\ \cline{1-2} \cline{6-6}
-       15 -- 16 &                          & (\Infoprof)                & (ab 24.04.)   & (\Infoprof)              &         \\ \cline{1-3} \cline{5-6}
-       16 -- 17 & Technische               &                            &               &                          &         \\ \cline{1-1} \cline{3-3} \cline{5-6}
-       17 -- 18 & Informatik II            &                            &               &                          &         \\ \cline{1-1} \cline{3-6}
-       18 -- 19 & (Prof. Menth)            &                            &               &                          &         \\ \hline
+       Zeit        & Montag                   	& Dienstag                   		& Mittwoch     	 & Donnerstag               		& Freitag \\ \hline
+       08 -- 09 &                          	& Technische Informatik II   	&              	     	&                          			&         \\ \cline{1-2} \cline{4-6}
+       09 -- 10 &                          	& (Prof. Menth)              	&               		&                         			 &         \\ \hline
+       10 -- 11 & Mathematik II            &                           	 	& Mathematik II 	&                         			&         \\ \cline{1-1} \cline{3-3} \cline{5-6}
+       11 -- 12 & (\Matheprof)             &                            		& (\Matheprof)  	&                          			&         \\ \hline
+       12 -- 13 &                          	&                            		&               		&                          			&         \\ \hline
+       13 -- 14 &                          	&                           		&	     	    	&                         		 	&         \\ \hline
+       14 -- 15 &                          	& Praktische Informatik II   	& Mathe 		& Praktische Informatik II	&         \\ \cline{1-2} \cline{6-6}
+       15 -- 16 &                          	& (\Infoprof)                		& Rechenzentrum& (\Infoprof)              		&         \\ \cline{1-3} \cline{5-6}
+       16 -- 17 & Technische              	&                            		& (ab 23.04.)         &                          		&         \\ \cline{1-1} \cline{3-3} \cline{5-6}	
+       17 -- 18 & Informatik II            	&                            		&           		&                         			&         \\ \cline{1-1} \cline{3-6}
+       18 -- 19 & (Prof. Menth)            	&                            		&           		&                          			&         \\ \hline
     \end{tabular}
     }
 
@@ -47,15 +47,15 @@ Semester neben der Informatikvorlesung auch eine gute Portion Mathe.
 Vollständiger Name: Mathematik für Informatik 2: Lineare Algebra\\
 Dieses Semester wird die Vorlesung im Hörsaal N7 auf der Morgenstelle stattfinden.
 Zusätzlich zur Vorlesung findet ein Tutorium statt. \\
-Ab dem 24.04. findet mittwochs das Rechenzentrum statt. Hier können Studierende gemeinsam die Aufgaben und Inhalte der Vorlesung diskutieren,
+Ab dem 23.04. findet mittwochs das Rechenzentrum statt. Hier können Studierende gemeinsam die Aufgaben und Inhalte der Vorlesung diskutieren,
 wobei auch Tutorinnen und Tutoren anwesend sein werden. Die Teilnahme am Rechenzentrum ist freiwillig.\\
 
 \textbf{Info 2}:\\
 Vollständiger Name: Praktische Informatik 2: Imperative und objektorientierte Programmierung\\
-Dieses Semester wird die Vorlesung wieder in Präsenz im Hörsaal N7 auf der Morgenstelle stattfinden.
-Zusätzlich werden Tutorien in Präsenz stattfinden.
+Dieses Semester wird die Vorlesung im Hörsaal N7 auf der Morgenstelle stattfinden.
+Zusätzlich werden Tutorien stattfinden.
 Die Zeiten für die Tutorien werden innerhalb der ersten Woche in den Vorlesungen bekannt gegeben.\\
-% Es wird für die Mathe II und die Info II auch noch freiwillige Zusatz-Tutorium und Einführungskurse geben.\\
+% Es wird für die Mathe II und die Info II auch noch freiwillige Zusatz-Tutorium und Einführungskurse geben.\\ TODO möglicherweise streichen
 
 \textbf{üBK}:\\
 Im Studienplan wird empfohlen eine übK\footnote{überfachlich berufsfeldorientierte Kompetenzen, in Zukunft auch Liberal Education genannt}
@@ -63,3 +63,4 @@ mit 3 LP zu belegen. Hier ist dir völlig freigestellt was du belegst, solange e
 Veranstaltung von gewissen Fächern (u.a. Medizin, Phsychologie) lassen sich jedoch nur hören, wenn du dieses als Schwerpunktfach gewählt hast.
 Hierdurch verlierst du jedoch die Freiheit der übK und darfst nur Vorlesungen aus diesen Fächern hören. Näheres erfährst du bei der fachspezifischen Begrüßung.
 
+\pagebreak

--- a/stundenplaene/stpl_informatik-lehramt_SS.tex
+++ b/stundenplaene/stpl_informatik-lehramt_SS.tex
@@ -1,4 +1,4 @@
-Wie du dem folgenden Stundenplan entnehmen kannst, enthält das Lehramtsstudium der Informatik im ersten Semester zunächst nur die Informatik II und Fachdidaktik-Vorlesung.
+Wie du dem folgenden Stundenplan entnehmen kannst, enthält das Lehramtsstudium der Informatik im ersten Semester zunächst nur die Informatik II-Vorlesung. Hinzu kommt noch das Seminar Fachdidaktik I, welches zwischen dem 01.09 und 05.09 als Blockveranstaltung stattfindet.
 Beachte, dass man auch pädagogische Studien schon im ersten Semester besuchen kann. Falls sich Veranstaltungen aus dem zweiten
 Fach mit Informatik überschneiden, kann man v.a. Informatik der Systeme aus dem vierten Semester tauschen.
 Wenn du dir noch einen genaueren Überblick über den Studienverlauf verschaffen möchtest, dann schau doch mal ins Modulhandbuch.
@@ -15,14 +15,15 @@ Wenn du dir noch einen genaueren Überblick über den Studienverlauf verschaffen
 		13 -- 14 &                            &          &                          \\ \hline
 		14 -- 15 & Praktische Informatik II   &          & Praktische Informatik II \\ \cline{1-1} \cline{3-3}
 		15 -- 16 & (\Infoprof)                &          & (\Infoprof)              \\ \hline
-		16 -- 17 &                            &          & Fachdidaktik 1           \\ \cline{1-3}
-		17 -- 18 &                            &          & Dr. Appel (ab 17.04.)    \\ \hline
+		16 -- 17 &                            &          &           \\ \hline
+		17 -- 18 &                            &          &     \\ \hline
 		\end{tabular}
 
 \end{center}
 
 \textbf{Info 2}:\\
 Vollständiger Name: Praktische Informatik 2: Imperative und objektorientierte Programmierung\\
-Dieses Semester wird die Vorlesung wieder in Präsenz im Hörsaal N7 auf der Morgenstelle stattfinden.
-Zusätzlich werden Tutorien in Präsenz stattfinden.
+Dieses Semester wird die Vorlesung im Hörsaal N7 auf der Morgenstelle stattfinden.
+Zusätzlich werden Tutorien stattfinden.
 Die Zeiten für die Tutorien werden innerhalb der ersten Woche in den Vorlesungen bekannt gegeben.\\
+\\

--- a/stundenplaene/stpl_msc.tex
+++ b/stundenplaene/stpl_msc.tex
@@ -1,7 +1,7 @@
 Im Master kannst du deinen Stundenplan relativ frei zusammenstellen.
 
 \iflehramt
-	Im Wahlpflichtbereich musst Veranstaltungen aus den Wahlpflichtbereichen des B.Sc. Informatik oder des M.Sc. Informatik belegen. 
+	Im Wahlpflichtbereich musst du Veranstaltungen aus den Wahlpflichtbereichen des B.Sc. Informatik oder des M.Sc. Informatik belegen. 
 	Welche Veranstltungen dich interessieren und damit für dich in Frage kommen kannst du dem Modulhandbuch (\url{http://uni-tuebingen.de/de/74348}) oder Alma (\url{https://alma.uni-tuebingen.de}) entnehmen.
 \else
 	Wichtig ist dabei nur, dass du alle Wahlpflichtbereiche entsprechend deiner Prüfungsordnung abdeckst,


### PR DESCRIPTION
Updated the letters for the Sommersemester 2025.

This includes:

- updating the dates and times of the Ersti-Events
- updating the schedules for the new profs 
- updating the information in config. 
- adjusting pagebreaks
- reordering events so that the first and second iteration of the same event are listed directly below each other. 

There were no major changes made for this semester. 